### PR TITLE
feat: generate automatically contracts with matching rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,24 @@ after(() => {
 
 ```
 
+### cy.usePactWait([alias] | alias, [omitList], autoMatching)
+Listen to aliased `cy.intercept` network call(s), record network request and response to a pact file with automatic matching rules of "type" or omit response elements not used by the consumer
+
+**Example**
+```js
+before(() => {
+    cy.setupPact('ui-consumer', 'api-provider')
+    cy.intercept('GET', '/users').as('getAllUsers')
+})
+
+//... cypress test
+
+after(() => {
+    cy.usePactWait(['getAllUsers'], ['element_b', 'element_b'], true)
+})
+
+```
+
 ### cy.setupPactHeaderBlocklist([headers])
 Add a list of headers that will be excluded in a pact at test case level
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test": "jest --testPathPattern=test",
     "build": "tsc",
     "test:example": "cd example/todo-example && npm i && npm run build && npm run http-server && npm run cypress:run",
-    "release": "standard-version"
+    "release": "standard-version",
+    "prepare": "npm run build"
   },
   "author": "",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Cypress {
     interface Chainable {
-      usePactWait: (alias: AliasType) => Chainable
+      usePactWait: (alias: AliasType, omitList?: string[], autoMatching?: boolean) => Chainable
       usePactRequest: (option: AnyObject, alias: string) => Chainable
       usePactGet: (alias: string, pactConfig: PactConfigType) => Chainable
       setupPact: (consumerName: string, providerName: string) => Chainable<null>

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ const setupPactHeaderBlocklist = (headers: string[]) => {
   headersBlocklist = [...headers, ...headersBlocklist]
 }
 
-const usePactWait = (alias: AliasType) => {
+const usePactWait = (alias: AliasType, omitList: string[] = [], autoMatching: boolean = false) => {
   const formattedAlias = formatAlias(alias)
   // Cypress versions older than 8.2 do not have a currentTest objects
   const testCaseTitle = Cypress.currentTest ? Cypress.currentTest.title : ''
@@ -48,7 +48,9 @@ const usePactWait = (alias: AliasType) => {
           intercept,
           testCaseTitle: `${testCaseTitle}-${formattedAlias[index]}`,
           pactConfig,
-          blocklist: headersBlocklist
+          blocklist: headersBlocklist,
+          omitList,
+          autoMatching
         })
       })
     })
@@ -59,7 +61,9 @@ const usePactWait = (alias: AliasType) => {
         intercept: flattenIntercept,
         testCaseTitle: `${testCaseTitle}`,
         pactConfig,
-        blocklist: headersBlocklist
+        blocklist: headersBlocklist,
+        omitList,
+        autoMatching
       })
     })
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,16 +27,16 @@ export type Interaction = {
   } & BaseXHR
   response: {
     status: string | number | undefined
-    matchingRules: MatchingRule
+    matchingRules?: MatchingRule
   } & BaseXHR
 }
 
 export type XHRRequestAndResponse = {
   request:
-    | {
-        method: string
-        url: string
-      } & BaseXHR
+  | {
+    method: string
+    url: string
+  } & BaseXHR
   response: {
     statusCode: string | number | undefined
     statusText: string | undefined
@@ -75,7 +75,9 @@ export type PactFileType = {
   testCaseTitle: string
   pactConfig: PactConfigType
   blocklist?: string[],
-  content?: any 
+  omitList?: string[],
+  autoMatching?: boolean,
+  content?: any
 }
 
 export type MatchingRule = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export type Interaction = {
   } & BaseXHR
   response: {
     status: string | number | undefined
+    matchingRules: MatchingRule
   } & BaseXHR
 }
 
@@ -76,3 +77,9 @@ export type PactFileType = {
   blocklist?: string[],
   content?: any 
 }
+
+export type MatchingRule = {
+  [key: string]: {
+    match: string;
+  };
+};

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -112,6 +112,65 @@ describe('constructPactFile', () => {
     expect(result.provider.name).toBe('todo-api')
     expect(result.interactions.length).toBe(1)
   })
+
+  it('should create a file with matchingRules when requested', () => {
+    const newIntercept = {
+      request: {
+        method: 'POST',
+        url: 'https://localhost:3000/create',
+        body: 'hello'
+      },
+      response: {
+        statusCode: 201,
+        statusText: 'Created',
+        body: {
+          reply: 'bye'
+        }
+      }
+    } as XHRRequestAndResponse
+
+    const result = constructPactFile({
+      intercept: newIntercept,
+      testCaseTitle: 'create todo',
+      pactConfig: {
+        consumerName: 'ui-consumer',
+        providerName: 'todo-api'
+      },
+      autoMatching: true
+    })
+    expect(result.interactions.length).toBe(1)
+    expect(result.interactions[0].response.matchingRules).toStrictEqual({ "$.body.reply": { "match": "type" } })
+  })
+
+  it('should create a file omitting reponse elements when requested', () => {
+    const newIntercept = {
+      request: {
+        method: 'POST',
+        url: 'https://localhost:3000/create',
+        body: 'hello'
+      },
+      response: {
+        statusCode: 201,
+        statusText: 'Created',
+        body: {
+          reply: 'bye',
+          omit: 'ok'
+        }
+      }
+    } as XHRRequestAndResponse
+
+    const result = constructPactFile({
+      intercept: newIntercept,
+      testCaseTitle: 'create todo',
+      pactConfig: {
+        consumerName: 'ui-consumer',
+        providerName: 'todo-api'
+      },
+      omitList: ["omit"]
+    })
+    expect(result.interactions.length).toBe(1)
+    expect(result.interactions[0].response.body).toStrictEqual({ "reply": "bye" })
+  })
 })
 
 describe('readFile', () => {


### PR DESCRIPTION
Making the function `usePactWait` create pact contracts with matching rules.
The function now accepts two optional parameters:
- `omitList`, which will remove any element in the response body from being recorded into the contract file
- `autoMatching`, which once set true will generate the matching rules for each element in the response body, all of them in the format { "match": "type" },

Other minor changes:
-  add script `"prepare": "npm run build"` in the package.json
- some automatic indentation